### PR TITLE
Removed suppression of dead code warnings, made modules public instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "measurements"
 version = "0.3.0"
-authors = ["James O'Cull <jocull@delmarsd.com>", "Jonathan Pallant <github@thejpster.org.uk"]
+authors = ["James O'Cull <jocull@delmarsd.com>",
+          "Jonathan Pallant <github@thejpster.org.uk>",
+          "Hannah McLaughlin <h@mcla.ug>"]
 documentation = "https://docs.rs/crate/measurements"
 repository = "https://github.com/jocull/rust-measurements"
 keywords = ["measurements", "lengths", "weights", "temperatures", "volumes"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,19 @@
 mod measurement;
 pub use measurement::Measurement;
 
-#[allow(dead_code)]
-mod length;
+pub mod length;
 pub use length::Length;
 
-#[allow(dead_code)]
-mod temperature;
+pub mod temperature;
 pub use temperature::Temperature;
 
-#[allow(dead_code)]
-mod weight;
+pub mod weight;
 pub use weight::Weight;
 
-#[allow(dead_code)]
-mod volume;
+pub mod volume;
 pub use volume::Volume;
 
-#[allow(dead_code)]
-mod pressure;
+pub mod pressure;
 pub use pressure::Pressure;
 
 // Include when running tests, but don't export them


### PR DESCRIPTION
Let me know if I'm wrong, but I think this appropriate as this is meant to be used as a library.  So, anything public in the library doesn't need to be used internally (so won't generate a warning); anything private to the library that isn't used internally should be deleted.